### PR TITLE
tighter type checking when validating request body fields for contact form

### DIFF
--- a/pages/api/form-submission.ts
+++ b/pages/api/form-submission.ts
@@ -1,5 +1,6 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 import type { NextApiRequest, NextApiResponse } from "next";
+import { arrayOfAll } from "@/types";
 import { FormData, HCaptchaObject } from "@/app/contact/ContactForm";
 import { verify } from "hcaptcha";
 import { HCAPTCHA_SECRET } from "@/constants";
@@ -30,13 +31,13 @@ export default async function handler(
    * (basically, we are making sure that
    * each field inside the req.body is a string, if not, return false.)
    */
-  const requiredFields: (keyof VerifiedFormData)[] = [
+  const requiredFields = arrayOfAll<keyof VerifiedFormData>()(
     "name",
     "email",
     "message",
     "token",
-    "ekey",
-  ];
+    "ekey"
+  );
 
   const invalid = requiredFields.some(
     (field) => typeof req.body[field] !== "string"

--- a/types/index.ts
+++ b/types/index.ts
@@ -9,3 +9,28 @@ export type ButtonColours =
   | "cinnabar"
   | "independence"
   | "pinkLace";
+
+/**
+ * Typescript wizardry allowing us to produce a tuple that must contain a string
+ * for every key in an interface. Accidentally omitting some keys or including
+ * extras will cause a type error.
+ *
+ * Usage:
+ * ```
+ * interface Person {
+ *     name: string;
+ *     age: number;
+ * }
+ *
+ * const fields = arrayOfAll<keyof Person>()("name", "age");
+ * ```
+ *
+ * Source: https://stackoverflow.com/a/73457231
+ */
+export const arrayOfAll =
+  <T>() =>
+  <U extends T[]>(
+    ...array: U & ([T] extends [U[number]] ? unknown : Invalid<T>[])
+  ) =>
+    array;
+type Invalid<T> = ["Needs to be all of", T];


### PR DESCRIPTION
Earlier today, we wanted to make sure our array had a string for every key of an interface with none missing. The closest we got was this:

```ts
const requiredFields: (keyof VerifiedFormData)[] = [
    "name",
    "email",
    "message",
    "token",
    "ekey"
];
```

While it's close, it's still possible to accidentally leave some keys out without causing a type error. However, someone on stackoverflow wrote some [magical typescript](https://stackoverflow.com/a/73457231) that accomplishes exactly what we were trying to do.

This PR implements their solution.